### PR TITLE
Don't craft using items with Lore

### DIFF
--- a/FastCraft/src/co/kepler/fastcraft/recipe/Ingredient.java
+++ b/FastCraft/src/co/kepler/fastcraft/recipe/Ingredient.java
@@ -14,10 +14,12 @@ import co.kepler.fastcraft.FastCraft;
 public class Ingredient {
 	private MaterialData material;
 	private int amount;
+	private boolean hasLore;
 
 	public Ingredient(MaterialData material, int amount) {
 		this.material = material;
 		this.amount = amount;
+		this.hasLore = false;
 	}
 
 	public Ingredient(MaterialData material) {
@@ -26,10 +28,16 @@ public class Ingredient {
 
 	public Ingredient(ItemStack item, int amount) {
 		this(item.getData(), amount);
+		if (item.hasItemMeta()) {
+			hasLore = item.getItemMeta().hasLore();
+		}
 	}
 
 	public Ingredient(ItemStack item) {
 		this(item.getData(), 1);
+		if (item.hasItemMeta()) {
+			hasLore = item.getItemMeta().hasLore();
+		}
 	}
 
 	public Ingredient(Ingredient ingredient, int amount) {
@@ -68,6 +76,9 @@ public class Ingredient {
 
 	@SuppressWarnings("deprecation")
 	public boolean isSimilar(Ingredient i) {
+		if (hasLore) {
+			return false;
+		}
 		if (material.getItemType() != i.material.getItemType()) {
 			return false;
 		}

--- a/FastCraft/src/co/kepler/fastcraft/recipe/IngredientList.java
+++ b/FastCraft/src/co/kepler/fastcraft/recipe/IngredientList.java
@@ -68,7 +68,13 @@ public class IngredientList {
 	public void add(ItemStack... i) {
 		for (ItemStack is : i) {
 			if (is != null) {
-				add(new Ingredient(is, is.getAmount()));
+				boolean skip = false;
+				if (is.hasItemMeta()) {
+					skip = is.getItemMeta().hasLore();
+				}
+				if (!skip) {
+					add(new Ingredient(is, is.getAmount()));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Some plugins use LoreText to give items extra features so they shouldn't be used in normal crafting.
Although said plugins can stop players using them in the normal crafting window they can't cancel FastCraft crafting so instead FastCraft needs to check for Lore and discount them when it creates its crafting lists and takes items from player inventories.